### PR TITLE
feat: support resolve_table for polars dataframe and arrow table

### DIFF
--- a/src/rust/src/environment.rs
+++ b/src/rust/src/environment.rs
@@ -1,8 +1,10 @@
-use datafusion::datasource::TableProvider;
+use crate::execution::RGlareDbExecutionOutput;
+use arrow::array::RecordBatchReader;
+use arrow::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
+use datafusion::arrow::array::RecordBatch;
+use datafusion::datasource::{MemTable, TableProvider};
 use sqlexec::environment::EnvironmentReader;
 use std::sync::Arc;
-
-use crate::execution::RGlareDbExecutionOutput;
 
 #[derive(Debug, Clone, Copy)]
 pub struct REnvironmentReader;
@@ -31,6 +33,61 @@ impl EnvironmentReader for REnvironmentReader {
             return Ok(Some(Arc::new(exec) as Arc<dyn TableProvider>));
         }
 
+        if classes
+            .iter()
+            .any(|&s| s == "RPolarsDataFrame" || s == "ArrowTabular")
+        {
+            let sexp = savvy::Sexp(
+                savvy::eval_parse_text(format!(
+                    r#"base::get0(r"({name})") |> nanoarrow::as_nanoarrow_array_stream()"#
+                ))
+                .unwrap()
+                .inner(),
+            );
+            let stream_reader = ArrowArrayStreamReader::from_r(sexp).unwrap();
+            let schema = stream_reader.schema();
+            let batches =
+                stream_reader.collect::<Result<Vec<RecordBatch>, arrow::error::ArrowError>>()?;
+            let table = MemTable::try_new(schema, vec![batches])?;
+
+            return Ok(Some(Arc::new(table) as Arc<dyn TableProvider>));
+        }
+
         Ok(None)
+    }
+}
+
+trait FromRArrowArrayStream: Sized {
+    fn from_r(sexp: savvy::Sexp) -> Result<Self, savvy::Error>;
+}
+
+// Import nanoarrow_array_stream
+// Copied from https://github.com/JosiahParry/arrow-extendr/blob/1ff628cd5e9c208c1aff99bc8aa92a3b7b9303dc/src/from.rs#L286-L302
+impl FromRArrowArrayStream for ArrowArrayStreamReader {
+    fn from_r(sexp: savvy::Sexp) -> Result<Self, savvy::Error> {
+        if sexp
+            .get_class()
+            .unwrap_or_default()
+            .iter()
+            .all(|&s| s != "nanoarrow_array_stream")
+        {
+            return Err(savvy::Error::from("Not a nanoarrow_array_stream"));
+        }
+
+        let func = savvy::FunctionSexp(
+            savvy::eval_parse_text(r#"nanoarrow::nanoarrow_pointer_export"#)
+                .unwrap()
+                .inner(),
+        );
+
+        let stream = FFI_ArrowArrayStream::empty();
+        let stream_ptr = &stream as *const FFI_ArrowArrayStream as usize;
+        let mut args = savvy::FunctionArgs::new();
+        args.add("ptr_src", sexp)?;
+        args.add("ptr_dst", stream_ptr.to_string())?;
+
+        let _ = func.call(args)?;
+
+        ArrowArrayStreamReader::try_new(stream).map_err(|e| savvy::Error::from(e.to_string()))
     }
 }


### PR DESCRIPTION

```r
> df <- polars::as_polars_df(mtcars)
> glaredb_sql("select * from df") |> polars::as_polars_df()
shape: (32, 11)
┌──────┬─────┬───────┬───────┬───┬─────┬─────┬──────┬──────┐
│ mpg  ┆ cyl ┆ disp  ┆ hp    ┆ … ┆ vs  ┆ am  ┆ gear ┆ carb │
│ ---  ┆ --- ┆ ---   ┆ ---   ┆   ┆ --- ┆ --- ┆ ---  ┆ ---  │
│ f64  ┆ f64 ┆ f64   ┆ f64   ┆   ┆ f64 ┆ f64 ┆ f64  ┆ f64  │
╞══════╪═════╪═══════╪═══════╪═══╪═════╪═════╪══════╪══════╡
│ 21.0 ┆ 6.0 ┆ 160.0 ┆ 110.0 ┆ … ┆ 0.0 ┆ 1.0 ┆ 4.0  ┆ 4.0  │
│ 21.0 ┆ 6.0 ┆ 160.0 ┆ 110.0 ┆ … ┆ 0.0 ┆ 1.0 ┆ 4.0  ┆ 4.0  │
│ 22.8 ┆ 4.0 ┆ 108.0 ┆ 93.0  ┆ … ┆ 1.0 ┆ 1.0 ┆ 4.0  ┆ 1.0  │
│ 21.4 ┆ 6.0 ┆ 258.0 ┆ 110.0 ┆ … ┆ 1.0 ┆ 0.0 ┆ 3.0  ┆ 1.0  │
│ 18.7 ┆ 8.0 ┆ 360.0 ┆ 175.0 ┆ … ┆ 0.0 ┆ 0.0 ┆ 3.0  ┆ 2.0  │
│ …    ┆ …   ┆ …     ┆ …     ┆ … ┆ …   ┆ …   ┆ …    ┆ …    │
│ 30.4 ┆ 4.0 ┆ 95.1  ┆ 113.0 ┆ … ┆ 1.0 ┆ 1.0 ┆ 5.0  ┆ 2.0  │
│ 15.8 ┆ 8.0 ┆ 351.0 ┆ 264.0 ┆ … ┆ 0.0 ┆ 1.0 ┆ 5.0  ┆ 4.0  │
│ 19.7 ┆ 6.0 ┆ 145.0 ┆ 175.0 ┆ … ┆ 0.0 ┆ 1.0 ┆ 5.0  ┆ 6.0  │
│ 15.0 ┆ 8.0 ┆ 301.0 ┆ 335.0 ┆ … ┆ 0.0 ┆ 1.0 ┆ 5.0  ┆ 8.0  │
│ 21.4 ┆ 4.0 ┆ 121.0 ┆ 109.0 ┆ … ┆ 1.0 ┆ 1.0 ┆ 4.0  ┆ 2.0  │
└──────┴─────┴───────┴───────┴───┴─────┴─────┴──────┴──────┘
```