### PR TITLE
feat: capture the environment where the connection was created with

### DIFF
--- a/R/000-wrappers.R
+++ b/R/000-wrappers.R
@@ -20,13 +20,13 @@ NULL
 }
 
 
-sql <- function(query) {
-  .savvy_wrap_RGlareDbExecutionOutput(.Call(savvy_sql__impl, query))
+sql <- function(query, env = NULL) {
+  .savvy_wrap_RGlareDbExecutionOutput(.Call(savvy_sql__impl, query, env))
 }
 
 
-connect <- function(cloud_addr, disable_tls, data_dir_or_cloud_url = NULL, spill_path = NULL, location = NULL) {
-  .savvy_wrap_RGlareDbConnection(.Call(savvy_connect__impl, cloud_addr, disable_tls, data_dir_or_cloud_url, spill_path, location))
+connect <- function(cloud_addr, disable_tls, data_dir_or_cloud_url = NULL, spill_path = NULL, location = NULL, env = NULL) {
+  .savvy_wrap_RGlareDbConnection(.Call(savvy_connect__impl, cloud_addr, disable_tls, data_dir_or_cloud_url, spill_path, location, env))
 }
 
 ### wrapper functions for RGlareDbConnection

--- a/R/000-wrappers.R
+++ b/R/000-wrappers.R
@@ -20,8 +20,8 @@ NULL
 }
 
 
-sql <- function(query, env = NULL) {
-  .savvy_wrap_RGlareDbExecutionOutput(.Call(savvy_sql__impl, query, env))
+sql <- function(query) {
+  .savvy_wrap_RGlareDbExecutionOutput(.Call(savvy_sql__impl, query))
 }
 
 

--- a/R/connect.R
+++ b/R/connect.R
@@ -7,6 +7,7 @@
 #' @param disable_tls `TRUE` or `FALSE` to indicating whether to disable TLS.
 #' @param cloud_addr A character of a GlareDB cloud URL.
 #' @param location TODO
+#' @param env TODO
 #' @return GlareDB connection object
 #' @export
 #' @examples
@@ -20,12 +21,14 @@ glaredb_connect <- function(
     spill_path = NULL,
     disable_tls = FALSE,
     cloud_addr = "https://console.glaredb.com",
-    location = NULL) {
+    location = NULL,
+    env = parent.frame()) {
   connect(
     cloud_addr = cloud_addr,
     disable_tls = disable_tls,
     data_dir_or_cloud_url = data_dir_or_cloud_url,
     spill_path = spill_path,
-    location = location
+    location = location,
+    env = env
   )
 }

--- a/R/query.R
+++ b/R/query.R
@@ -6,6 +6,6 @@
 #' @examples
 #' glaredb_sql("SELECT 'hello from R' as hello") |>
 #'   as.data.frame()
-glaredb_sql <- function(query, env = parent.frame()) {
-  sql(query, env = env)
+glaredb_sql <- function(query) {
+  sql(query)
 }

--- a/R/query.R
+++ b/R/query.R
@@ -1,10 +1,11 @@
 #' Run a SQL query against the default in-memory GlareDB database
 #' @param query A character of the SQL query to run
+#' @param env TODO
 #' @return GlareDB execusion output
 #' @export
 #' @examples
 #' glaredb_sql("SELECT 'hello from R' as hello") |>
 #'   as.data.frame()
-glaredb_sql <- function(query) {
-  sql(query)
+glaredb_sql <- function(query, env = parent.frame()) {
+  sql(query, env = env)
 }

--- a/src/init.c
+++ b/src/init.c
@@ -34,13 +34,13 @@ SEXP handle_result(SEXP res_) {
     return (SEXP)res;
 }
 
-SEXP savvy_sql__impl(SEXP query) {
-    SEXP res = savvy_sql__ffi(query);
+SEXP savvy_sql__impl(SEXP query, SEXP env) {
+    SEXP res = savvy_sql__ffi(query, env);
     return handle_result(res);
 }
 
-SEXP savvy_connect__impl(SEXP cloud_addr, SEXP disable_tls, SEXP data_dir_or_cloud_url, SEXP spill_path, SEXP location) {
-    SEXP res = savvy_connect__ffi(cloud_addr, disable_tls, data_dir_or_cloud_url, spill_path, location);
+SEXP savvy_connect__impl(SEXP cloud_addr, SEXP disable_tls, SEXP data_dir_or_cloud_url, SEXP spill_path, SEXP location, SEXP env) {
+    SEXP res = savvy_connect__ffi(cloud_addr, disable_tls, data_dir_or_cloud_url, spill_path, location, env);
     return handle_result(res);
 }
 
@@ -57,8 +57,8 @@ SEXP savvy_RGlareDbExecutionOutput_export_stream__impl(SEXP self__, SEXP stream_
 
 
 static const R_CallMethodDef CallEntries[] = {
-    {"savvy_sql__impl", (DL_FUNC) &savvy_sql__impl, 1},
-    {"savvy_connect__impl", (DL_FUNC) &savvy_connect__impl, 5},
+    {"savvy_sql__impl", (DL_FUNC) &savvy_sql__impl, 2},
+    {"savvy_connect__impl", (DL_FUNC) &savvy_connect__impl, 6},
     {"savvy_RGlareDbConnection_sql__impl", (DL_FUNC) &savvy_RGlareDbConnection_sql__impl, 2},
     {"savvy_RGlareDbExecutionOutput_export_stream__impl", (DL_FUNC) &savvy_RGlareDbExecutionOutput_export_stream__impl, 2},
 

--- a/src/init.c
+++ b/src/init.c
@@ -34,8 +34,8 @@ SEXP handle_result(SEXP res_) {
     return (SEXP)res;
 }
 
-SEXP savvy_sql__impl(SEXP query, SEXP env) {
-    SEXP res = savvy_sql__ffi(query, env);
+SEXP savvy_sql__impl(SEXP query) {
+    SEXP res = savvy_sql__ffi(query);
     return handle_result(res);
 }
 
@@ -57,7 +57,7 @@ SEXP savvy_RGlareDbExecutionOutput_export_stream__impl(SEXP self__, SEXP stream_
 
 
 static const R_CallMethodDef CallEntries[] = {
-    {"savvy_sql__impl", (DL_FUNC) &savvy_sql__impl, 2},
+    {"savvy_sql__impl", (DL_FUNC) &savvy_sql__impl, 1},
     {"savvy_connect__impl", (DL_FUNC) &savvy_connect__impl, 6},
     {"savvy_RGlareDbConnection_sql__impl", (DL_FUNC) &savvy_RGlareDbConnection_sql__impl, 2},
     {"savvy_RGlareDbExecutionOutput_export_stream__impl", (DL_FUNC) &savvy_RGlareDbExecutionOutput_export_stream__impl, 2},

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -6765,7 +6765,7 @@ checksum = "ece8e78b2f38ec51c51f5d475df0a7187ba5111b2a28bdc761ee05b075d40a71"
 [[package]]
 name = "savvy"
 version = "0.6.3"
-source = "git+https://github.com/yutannihilation/savvy?branch=env#b744e8206c46db6468f663a596fd2d39e1154da9"
+source = "git+https://github.com/yutannihilation/savvy?branch=env#be4e43b724cb90811277e6a3d8333f658ae8b639"
 dependencies = [
  "cc",
  "once_cell",
@@ -6776,7 +6776,7 @@ dependencies = [
 [[package]]
 name = "savvy-bindgen"
 version = "0.6.3"
-source = "git+https://github.com/yutannihilation/savvy?branch=env#b744e8206c46db6468f663a596fd2d39e1154da9"
+source = "git+https://github.com/yutannihilation/savvy?branch=env#be4e43b724cb90811277e6a3d8333f658ae8b639"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6786,12 +6786,12 @@ dependencies = [
 [[package]]
 name = "savvy-ffi"
 version = "0.6.3"
-source = "git+https://github.com/yutannihilation/savvy?branch=env#b744e8206c46db6468f663a596fd2d39e1154da9"
+source = "git+https://github.com/yutannihilation/savvy?branch=env#be4e43b724cb90811277e6a3d8333f658ae8b639"
 
 [[package]]
 name = "savvy-macro"
 version = "0.6.3"
-source = "git+https://github.com/yutannihilation/savvy?branch=env#b744e8206c46db6468f663a596fd2d39e1154da9"
+source = "git+https://github.com/yutannihilation/savvy?branch=env#be4e43b724cb90811277e6a3d8333f658ae8b639"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -6765,7 +6765,7 @@ checksum = "ece8e78b2f38ec51c51f5d475df0a7187ba5111b2a28bdc761ee05b075d40a71"
 [[package]]
 name = "savvy"
 version = "0.6.3"
-source = "git+https://github.com/yutannihilation/savvy?branch=env#be4e43b724cb90811277e6a3d8333f658ae8b639"
+source = "git+https://github.com/yutannihilation/savvy?rev=b0002cecf8aaecc9071ae65a6772691bbbd4063e#b0002cecf8aaecc9071ae65a6772691bbbd4063e"
 dependencies = [
  "cc",
  "once_cell",
@@ -6776,7 +6776,7 @@ dependencies = [
 [[package]]
 name = "savvy-bindgen"
 version = "0.6.3"
-source = "git+https://github.com/yutannihilation/savvy?branch=env#be4e43b724cb90811277e6a3d8333f658ae8b639"
+source = "git+https://github.com/yutannihilation/savvy?rev=b0002cecf8aaecc9071ae65a6772691bbbd4063e#b0002cecf8aaecc9071ae65a6772691bbbd4063e"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6786,12 +6786,12 @@ dependencies = [
 [[package]]
 name = "savvy-ffi"
 version = "0.6.3"
-source = "git+https://github.com/yutannihilation/savvy?branch=env#be4e43b724cb90811277e6a3d8333f658ae8b639"
+source = "git+https://github.com/yutannihilation/savvy?rev=b0002cecf8aaecc9071ae65a6772691bbbd4063e#b0002cecf8aaecc9071ae65a6772691bbbd4063e"
 
 [[package]]
 name = "savvy-macro"
 version = "0.6.3"
-source = "git+https://github.com/yutannihilation/savvy?branch=env#be4e43b724cb90811277e6a3d8333f658ae8b639"
+source = "git+https://github.com/yutannihilation/savvy?rev=b0002cecf8aaecc9071ae65a6772691bbbd4063e#b0002cecf8aaecc9071ae65a6772691bbbd4063e"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/rust/Cargo.lock
+++ b/src/rust/Cargo.lock
@@ -6765,7 +6765,7 @@ checksum = "ece8e78b2f38ec51c51f5d475df0a7187ba5111b2a28bdc761ee05b075d40a71"
 [[package]]
 name = "savvy"
 version = "0.6.3"
-source = "git+https://github.com/yutannihilation/savvy?rev=08895ae2d8207ea2918fc5bb31f826c2e88a2959#08895ae2d8207ea2918fc5bb31f826c2e88a2959"
+source = "git+https://github.com/yutannihilation/savvy?branch=env#b744e8206c46db6468f663a596fd2d39e1154da9"
 dependencies = [
  "cc",
  "once_cell",
@@ -6776,7 +6776,7 @@ dependencies = [
 [[package]]
 name = "savvy-bindgen"
 version = "0.6.3"
-source = "git+https://github.com/yutannihilation/savvy?rev=08895ae2d8207ea2918fc5bb31f826c2e88a2959#08895ae2d8207ea2918fc5bb31f826c2e88a2959"
+source = "git+https://github.com/yutannihilation/savvy?branch=env#b744e8206c46db6468f663a596fd2d39e1154da9"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -6786,12 +6786,12 @@ dependencies = [
 [[package]]
 name = "savvy-ffi"
 version = "0.6.3"
-source = "git+https://github.com/yutannihilation/savvy?rev=08895ae2d8207ea2918fc5bb31f826c2e88a2959#08895ae2d8207ea2918fc5bb31f826c2e88a2959"
+source = "git+https://github.com/yutannihilation/savvy?branch=env#b744e8206c46db6468f663a596fd2d39e1154da9"
 
 [[package]]
 name = "savvy-macro"
 version = "0.6.3"
-source = "git+https://github.com/yutannihilation/savvy?rev=08895ae2d8207ea2918fc5bb31f826c2e88a2959#08895ae2d8207ea2918fc5bb31f826c2e88a2959"
+source = "git+https://github.com/yutannihilation/savvy?branch=env#b744e8206c46db6468f663a596fd2d39e1154da9"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 # savvy = "0.6.3" # TODO: update after > 0.6.3 released
-savvy = { git = "https://github.com/yutannihilation/savvy", branch = "env" }
+savvy = { git = "https://github.com/yutannihilation/savvy", rev = "b0002cecf8aaecc9071ae65a6772691bbbd4063e" }
 datafusion = { version = "36.0.0", features = ["avro"] }
 tokio = { version = "1", features = ["full"] }
 arrow = { version = "50.0.0", features = ["ffi"] }

--- a/src/rust/Cargo.toml
+++ b/src/rust/Cargo.toml
@@ -9,7 +9,7 @@ crate-type = ["staticlib"]
 
 [dependencies]
 # savvy = "0.6.3" # TODO: update after > 0.6.3 released
-savvy = { git = "https://github.com/yutannihilation/savvy", rev = "08895ae2d8207ea2918fc5bb31f826c2e88a2959" }
+savvy = { git = "https://github.com/yutannihilation/savvy", branch = "env" }
 datafusion = { version = "36.0.0", features = ["avro"] }
 tokio = { version = "1", features = ["full"] }
 arrow = { version = "50.0.0", features = ["ffi"] }

--- a/src/rust/api.h
+++ b/src/rust/api.h
@@ -1,5 +1,5 @@
-SEXP savvy_sql__ffi(SEXP query);
-SEXP savvy_connect__ffi(SEXP cloud_addr, SEXP disable_tls, SEXP data_dir_or_cloud_url, SEXP spill_path, SEXP location);
+SEXP savvy_sql__ffi(SEXP query, SEXP env);
+SEXP savvy_connect__ffi(SEXP cloud_addr, SEXP disable_tls, SEXP data_dir_or_cloud_url, SEXP spill_path, SEXP location, SEXP env);
 
 // methods and associated functions for RGlareDbConnection
 SEXP savvy_RGlareDbConnection_sql__ffi(SEXP self__, SEXP query);

--- a/src/rust/api.h
+++ b/src/rust/api.h
@@ -1,4 +1,4 @@
-SEXP savvy_sql__ffi(SEXP query, SEXP env);
+SEXP savvy_sql__ffi(SEXP query);
 SEXP savvy_connect__ffi(SEXP cloud_addr, SEXP disable_tls, SEXP data_dir_or_cloud_url, SEXP spill_path, SEXP location, SEXP env);
 
 // methods and associated functions for RGlareDbConnection

--- a/src/rust/src/connect.rs
+++ b/src/rust/src/connect.rs
@@ -2,22 +2,24 @@ use crate::connection::RGlareDbConnection;
 use crate::environment::REnvironmentReader;
 use crate::error::RGlareDbError;
 use crate::runtime::GLOBAL_RUNTIME;
-use savvy::savvy;
+use savvy::{savvy, EnvironmentSexp};
 use std::sync::Arc;
 
 #[savvy]
-pub fn connect(
+pub fn connect_(
     cloud_addr: &str,
     disable_tls: bool,
     data_dir_or_cloud_url: Option<&str>,
     spill_path: Option<&str>,
     location: Option<&str>,
+    env: Option<EnvironmentSexp>,
     // storage_options: Option<HashMap<String, String>>, // TODO: support storage options
 ) -> savvy::Result<RGlareDbConnection> {
     let data_dir_or_cloud_url = data_dir_or_cloud_url.map(|s| s.to_string());
     let spill_path = spill_path.map(|s| s.to_string());
     let cloud_addr = cloud_addr.to_string();
     let location = location.map(|s| s.to_string());
+    let env = env.unwrap_or(EnvironmentSexp::global_env());
 
     GLOBAL_RUNTIME.0.block_on(async move {
         Ok(RGlareDbConnection {
@@ -29,7 +31,7 @@ pub fn connect(
                     .disable_tls(disable_tls)
                     .cloud_addr(cloud_addr)
                     .client_type(sqlexec::remote::client::RemoteClientType::Rust)
-                    .environment_reader(Arc::new(REnvironmentReader))
+                    .environment_reader(Arc::new(REnvironmentReader::new(env)))
                     .build()
                     .map_err(RGlareDbError::from)?
                     .connect()

--- a/src/rust/src/connect.rs
+++ b/src/rust/src/connect.rs
@@ -6,7 +6,7 @@ use savvy::{savvy, EnvironmentSexp};
 use std::sync::Arc;
 
 #[savvy]
-pub fn connect_(
+pub fn connect(
     cloud_addr: &str,
     disable_tls: bool,
     data_dir_or_cloud_url: Option<&str>,

--- a/src/rust/src/connection.rs
+++ b/src/rust/src/connection.rs
@@ -14,7 +14,7 @@ struct RGlareDbConnection {
 
 impl RGlareDbConnection {
     // TODO: support async
-    pub fn default_in_memory(env: EnvironmentSexp) -> savvy::Result<RGlareDbConnection> {
+    pub fn default_in_memory() -> savvy::Result<RGlareDbConnection> {
         static DEFAULT_CON: OnceCell<RGlareDbConnection> = OnceCell::new();
 
         let con = DEFAULT_CON.get_or_try_init(|| {
@@ -22,7 +22,9 @@ impl RGlareDbConnection {
                 Ok(RGlareDbConnection {
                     inner: Arc::new(
                         glaredb::ConnectOptionsBuilder::new_in_memory()
-                            .environment_reader(Arc::new(REnvironmentReader::new(env)))
+                            .environment_reader(Arc::new(REnvironmentReader::new(
+                                EnvironmentSexp::global_env(),
+                            )))
                             .build()?
                             .connect()
                             .await?,

--- a/src/rust/src/connection.rs
+++ b/src/rust/src/connection.rs
@@ -3,7 +3,7 @@ use crate::error::RGlareDbError;
 use crate::execution::RGlareDbExecutionOutput;
 use crate::runtime::GLOBAL_RUNTIME;
 use once_cell::sync::OnceCell;
-use savvy::savvy;
+use savvy::{savvy, EnvironmentSexp};
 use std::sync::Arc;
 
 #[savvy]
@@ -14,7 +14,7 @@ struct RGlareDbConnection {
 
 impl RGlareDbConnection {
     // TODO: support async
-    pub fn default_in_memory() -> savvy::Result<RGlareDbConnection> {
+    pub fn default_in_memory(env: EnvironmentSexp) -> savvy::Result<RGlareDbConnection> {
         static DEFAULT_CON: OnceCell<RGlareDbConnection> = OnceCell::new();
 
         let con = DEFAULT_CON.get_or_try_init(|| {
@@ -22,7 +22,7 @@ impl RGlareDbConnection {
                 Ok(RGlareDbConnection {
                     inner: Arc::new(
                         glaredb::ConnectOptionsBuilder::new_in_memory()
-                            .environment_reader(Arc::new(REnvironmentReader))
+                            .environment_reader(Arc::new(REnvironmentReader::new(env)))
                             .build()?
                             .connect()
                             .await?,

--- a/src/rust/src/environment.rs
+++ b/src/rust/src/environment.rs
@@ -5,7 +5,7 @@ use datafusion::arrow::array::RecordBatch;
 use datafusion::datasource::{MemTable, TableProvider};
 use savvy::ffi::SEXP;
 use savvy::protect::{insert_to_preserved_list, release_from_preserved_list};
-use savvy::EnvironmentSexp;
+use savvy::{EnvironmentSexp, Sexp};
 use sqlexec::environment::EnvironmentReader;
 use std::sync::{Arc, Mutex};
 
@@ -66,13 +66,17 @@ impl EnvironmentReader for REnvironmentReader {
             .iter()
             .any(|&s| s == "RPolarsDataFrame" || s == "ArrowTabular")
         {
-            let sexp = savvy::Sexp(
-                savvy::eval_parse_text(format!(
-                    r#"base::get0(r"({name})") |> nanoarrow::as_nanoarrow_array_stream()"#
-                ))
+            let func = savvy::FunctionSexp::try_from(savvy::Sexp(
+                savvy::eval_parse_text(
+                    r#"utils::getFromNamespace("as_nanoarrow_array_stream", "nanoarrow")"#,
+                )
                 .unwrap()
                 .inner(),
-            );
+            ))
+            .unwrap();
+            let mut args = savvy::FunctionArgs::new();
+            let _ = args.add("x", obj);
+            let sexp = Sexp::try_from(func.call(args).unwrap()).unwrap();
             let stream_ptr = savvy::ExternalPointerSexp::try_from(sexp).unwrap();
             let stream = unsafe { stream_ptr.cast_mut_unchecked::<FFI_ArrowArrayStream>() };
             let stream_reader = unsafe { ArrowArrayStreamReader::from_raw(stream).unwrap() };

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -6,9 +6,11 @@ mod execution;
 mod runtime;
 use connection::RGlareDbConnection;
 use execution::RGlareDbExecutionOutput;
-use savvy::savvy;
+use savvy::{savvy, EnvironmentSexp};
 
 #[savvy]
-pub fn sql(query: &str) -> savvy::Result<RGlareDbExecutionOutput> {
-    RGlareDbConnection::default_in_memory()?.sql(query)
+pub fn sql_(query: &str, env: Option<EnvironmentSexp>) -> savvy::Result<RGlareDbExecutionOutput> {
+    let env = env.unwrap_or(EnvironmentSexp::global_env());
+
+    RGlareDbConnection::default_in_memory(env)?.sql(query)
 }

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -6,11 +6,9 @@ mod execution;
 mod runtime;
 use connection::RGlareDbConnection;
 use execution::RGlareDbExecutionOutput;
-use savvy::{savvy, EnvironmentSexp};
+use savvy::savvy;
 
 #[savvy]
-pub fn sql(query: &str, env: Option<EnvironmentSexp>) -> savvy::Result<RGlareDbExecutionOutput> {
-    let env = env.unwrap_or(EnvironmentSexp::global_env());
-
-    RGlareDbConnection::default_in_memory(env)?.sql(query)
+pub fn sql(query: &str) -> savvy::Result<RGlareDbExecutionOutput> {
+    RGlareDbConnection::default_in_memory()?.sql(query)
 }

--- a/src/rust/src/lib.rs
+++ b/src/rust/src/lib.rs
@@ -9,7 +9,7 @@ use execution::RGlareDbExecutionOutput;
 use savvy::{savvy, EnvironmentSexp};
 
 #[savvy]
-pub fn sql_(query: &str, env: Option<EnvironmentSexp>) -> savvy::Result<RGlareDbExecutionOutput> {
+pub fn sql(query: &str, env: Option<EnvironmentSexp>) -> savvy::Result<RGlareDbExecutionOutput> {
     let env = env.unwrap_or(EnvironmentSexp::global_env());
 
     RGlareDbConnection::default_in_memory(env)?.sql(query)


### PR DESCRIPTION
My attempt for https://github.com/yutannihilation/savvy/pull/254.

Note that this implementation is probably incorrect. I manually mark `Send` and `Sync`, but we cannot call R API concurrently anyway.