### PR TITLE
dev: set up rust formatter

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -31,6 +31,6 @@
 	},
 	"remoteEnv": {
 		"PKG_SYSREQS": "false"
-	}
-	// "updateContentCommand": "task setup-dev"
+	},
+	"updateContentCommand": "task setup-dev"
 }

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -13,6 +13,29 @@ vars:
   RUST_SOURCE: src/rust/src/**/*.rs
 
 tasks:
+  setup-dev:
+    desc: Install tools for development.
+    deps:
+      - setup-rust-tools
+
+  setup-rust-tools:
+    desc: Install Rust tools for development.
+    cmds:
+      # TODO: check the savvy version
+      - cargo install savvy-cli
+      - rustup toolchain install nightly
+      - rustup component add rustfmt --toolchain nightly
+
+  format-rust:
+    desc: Format Rust code.
+    sources:
+      - "{{.RUST_SOURCE}}"
+    generates:
+      - "{{.RUST_SOURCE}}"
+    dir: src/rust
+    cmds:
+      - cargo +nightly fmt
+
   build-rust:
     desc: Build the Rust library wrappers.
     sources:
@@ -21,6 +44,8 @@ tasks:
       - "{{.MANIFEST}}"
       - "{{.CARGO_LOCK}}"
       - "{{.RUST_SOURCE}}"
+    deps:
+      - format-rust
     generates:
       - R/000-wrappers.R
     cmds:

--- a/src/rust/rustfmt.toml
+++ b/src/rust/rustfmt.toml
@@ -1,0 +1,16 @@
+edition = "2021"
+comment_width = 100
+combine_control_expr = true
+format_code_in_doc_comments = true
+condense_wildcard_suffixes = false
+format_strings = false
+normalize_comments = false
+wrap_comments = false
+hard_tabs = false
+reorder_impl_items = false
+imports_layout = "HorizontalVertical"
+imports_granularity = "Module"
+newline_style = "Unix"
+group_imports = "StdExternalCrate"
+blank_lines_lower_bound = 0
+blank_lines_upper_bound = 2

--- a/src/rust/src/connect.rs
+++ b/src/rust/src/connect.rs
@@ -1,10 +1,12 @@
+use std::collections::HashMap;
+use std::sync::Arc;
+
+use savvy::{savvy, EnvironmentSexp, StringSexp};
+
 use crate::connection::RGlareDbConnection;
 use crate::environment::REnvironmentReader;
 use crate::error::RGlareDbDatabaseError;
 use crate::runtime::GLOBAL_RUNTIME;
-use savvy::{savvy, EnvironmentSexp, StringSexp};
-use std::collections::HashMap;
-use std::sync::Arc;
 
 #[savvy]
 pub fn connect(

--- a/src/rust/src/connection.rs
+++ b/src/rust/src/connection.rs
@@ -1,10 +1,12 @@
+use std::sync::Arc;
+
+use once_cell::sync::OnceCell;
+use savvy::{savvy, EnvironmentSexp};
+
 use crate::environment::REnvironmentReader;
 use crate::error::RGlareDbDatabaseError;
 use crate::execution::RGlareDbExecutionOutput;
 use crate::runtime::GLOBAL_RUNTIME;
-use once_cell::sync::OnceCell;
-use savvy::{savvy, EnvironmentSexp};
-use std::sync::Arc;
 
 #[savvy]
 #[derive(Clone)]

--- a/src/rust/src/environment.rs
+++ b/src/rust/src/environment.rs
@@ -1,11 +1,13 @@
-use crate::execution::RGlareDbExecutionOutput;
-use crate::table::RGlareDbTable;
+use std::sync::{Arc, Mutex};
+
 use datafusion::datasource::{MemTable, TableProvider};
 use glaredb::EnvironmentReader;
 use savvy::ffi::SEXP;
 use savvy::protect::{insert_to_preserved_list, release_from_preserved_list};
 use savvy::{EnvironmentSexp, Sexp};
-use std::sync::{Arc, Mutex};
+
+use crate::execution::RGlareDbExecutionOutput;
+use crate::table::RGlareDbTable;
 
 // TODO
 struct UnsafeToken(SEXP);

--- a/src/rust/src/environment.rs
+++ b/src/rust/src/environment.rs
@@ -2,7 +2,6 @@ use std::sync::{Arc, Mutex};
 
 use glaredb::ext::datafusion::datasource::{MemTable, TableProvider};
 use glaredb::ext::EnvironmentReader;
-use glaredb::EnvironmentReader;
 use savvy::ffi::SEXP;
 use savvy::protect::{insert_to_preserved_list, release_from_preserved_list};
 use savvy::{EnvironmentSexp, Sexp};

--- a/src/rust/src/execution.rs
+++ b/src/rust/src/execution.rs
@@ -1,5 +1,6 @@
-use crate::runtime::GLOBAL_RUNTIME;
-use crate::table::RGlareDbTable;
+use std::any::Any;
+use std::sync::{Arc, Mutex};
+
 use arrow::datatypes::Schema;
 use async_trait::async_trait;
 use datafusion::arrow::datatypes::SchemaRef;
@@ -14,8 +15,9 @@ use datafusion::physical_plan::ExecutionPlan;
 use datafusion::prelude::Expr;
 use glaredb::{Operation, SendableRecordBatchStream};
 use savvy::savvy;
-use std::any::Any;
-use std::sync::{Arc, Mutex};
+
+use crate::runtime::GLOBAL_RUNTIME;
+use crate::table::RGlareDbTable;
 
 #[savvy]
 #[derive(Clone, Debug)]

--- a/src/rust/src/runtime.rs
+++ b/src/rust/src/runtime.rs
@@ -1,5 +1,6 @@
-use savvy::savvy;
 use std::sync::atomic::{AtomicU64, Ordering};
+
+use savvy::savvy;
 use tokio::runtime::Builder;
 
 #[savvy]

--- a/src/rust/src/table.rs
+++ b/src/rust/src/table.rs
@@ -1,10 +1,11 @@
+use std::sync::Arc;
+
 use arrow::array::RecordBatchReader;
 use arrow::datatypes::Schema;
 use arrow::ffi_stream::{ArrowArrayStreamReader, FFI_ArrowArrayStream};
 use datafusion::arrow::array::RecordBatch;
 use datafusion::datasource::MemTable;
 use savvy::savvy;
-use std::sync::Arc;
 
 #[savvy]
 struct RGlareDbTable {


### PR DESCRIPTION
This is the same lint configuration as GlareDB. The main thin I'm interested in is getting the linter to respect the edition of rust, but the other stuff seems fine too.

Run (with appropriate toolchain installed, typically via rustup):

```bash
cargo +nightly fmt
```