### PR TITLE
fix: ensure report rustc version if using pre-built binary

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,9 @@
 # glaredb (development version)
 
+## Bug fixes
+
+- Fix to report rustc version even if installing with pre-built binaries. (#71)
+
 # glaredb 0.0.3
 
 - Based on glaredb 0.9.5. (#56, thanks @tychoish)

--- a/configure
+++ b/configure
@@ -68,6 +68,8 @@ check_bin_lib() {
     echo ""
     echo "---------------------- [LIBRARY BINARY FOUND] ----------------------"
     echo "The library was found at <${LIBR_GLAREDB_PATH}>. No need to build it."
+    echo ""
+    echo "Note: rustc version: $(rustc -V || echo 'Not found')"
     echo "--------------------------------------------------------------------"
     echo ""
     sed -e "s|@TARGET@||" src/Makevars.in >src/Makevars


### PR DESCRIPTION
It seems that to avoid the warnings on this repository and on R-universe, it is necessary to show the version of rustc even when using pre-built binaries.
https://github.com/r-devel/r-svn/commit/6114d4126434c056b476cbc5db2657536c153d9a